### PR TITLE
Remove bimi-sep from bimi-indicator-header definition

### DIFF
--- a/draft-brand-indicators-for-message-identification.md
+++ b/draft-brand-indicators-for-message-identification.md
@@ -597,7 +597,7 @@ file then the MTA MUST uncompress the file before base64 encoding.
 
 And the formal definition of the BIMI Indicator Header, using ABNF, is as follows:
 
-    bimi-indicator-header = bimi-sep base64string \[bimi-sep\]
+    bimi-indicator-header = base64string
 
 ## Header Signing
 


### PR DESCRIPTION
Fixes #29 

Note, I have not rebuild the target files in this MR as there is a Makefile fix in https://github.com/authindicators/rfc-brand-indicators-for-message-identification/pull/30 that is preventing the build. Once these are both merged I will rebuild.